### PR TITLE
quoteAssetVolume and quoteVolume is not the same

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -138,7 +138,7 @@ export const candleFields = [
   'close',
   'volume',
   'closeTime',
-  'quoteAssetVolume',
+  'quoteVolume',
   'trades',
   'baseAssetVolume',
   'quoteAssetVolume',


### PR DESCRIPTION
Don't let those two candle fields have the same name. This results in one being overriden by the other.