### PR TITLE
fix: update type definition for NewOrder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -455,6 +455,10 @@ declare module 'binance-api-node' {
     useServerTime?: boolean
     type: OrderType
     newOrderRespType?: NewOrderRespType
+    closePosition?: boolean
+    workingType: WorkingType
+    callbackRate?: number
+    activationPrice?: number
   }
 
   export interface NewOcoOrder {
@@ -532,6 +536,7 @@ declare module 'binance-api-node' {
     | 'STOP_LOSS_LIMIT'
     | 'TAKE_PROFIT'
     | 'TAKE_PROFIT_LIMIT'
+    | 'TRAILING_STOP_MARKET'
 
   export type ListOrderStatus = 'EXECUTING' | 'ALL_DONE' | 'REJECT'
 
@@ -542,6 +547,8 @@ declare module 'binance-api-node' {
   export type NewOrderRespType = 'ACK' | 'RESULT' | 'FULL'
 
   export type TimeInForce = 'GTC' | 'IOC' | 'FOK'
+
+  export type WorkingType = 'MARK_PRICE' | 'CONTRACT_PRICE'
 
   export enum OrderRejectReason {
     ACCOUNT_CANNOT_SETTLE = 'ACCOUNT_CANNOT_SETTLE',


### PR DESCRIPTION
A few missing properties on NewOrder are added in this PR.

Source of properties: https://binance-docs.github.io/apidocs/futures/en/#new-order-trade

Primarily the trailing stop market is missing entirely in the current definition.