### PR TITLE
fix readme syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1967,6 +1967,7 @@ console.log(await client.dustTransfer({ asset: ['ETH', 'LTC', 'TRX'] }))
 
 <details>
 <summary>Output</summary>
+
 ```js
     
 {


### PR DESCRIPTION
readme file has syntax error that prevent showing others part after the dust transfer example